### PR TITLE
PB-1888 Sentry server environment

### DIFF
--- a/server.js
+++ b/server.js
@@ -153,7 +153,7 @@ if (cluster.isMaster) {
 				"timestamp": Date.now(),
 				"project": config.sentry.projects[xml.notice['api-key']].id,
 				"platform": config.sentry.projects[xml.notice['api-key']].platform,
-				"environment:" xml.notice['server-environment'][0]['environment-name'][0]
+				"environment": xml.notice['server-environment'][0]['environment-name'][0]
 			};
 
 			if (typeof(xml.notice.request) != "undefined") {

--- a/server.js
+++ b/server.js
@@ -152,7 +152,8 @@ if (cluster.isMaster) {
 				"logger": "",
 				"timestamp": Date.now(),
 				"project": config.sentry.projects[xml.notice['api-key']].id,
-				"platform": config.sentry.projects[xml.notice['api-key']].platform
+				"platform": config.sentry.projects[xml.notice['api-key']].platform,
+				"environment:" xml.notice['server-environment'][0]['environment-name'][0]
 			};
 
 			if (typeof(xml.notice.request) != "undefined") {


### PR DESCRIPTION
### Goals
- **[EP-298](https://globalpersonals.atlassian.net/browse/EP-298)** Platform stability 
- **[PB-1888](https://globalpersonals.atlassian.net/browse/PB-1888):** Set up Sentry on UAT boxes
- **[WIN-462](https://globalpersonals.atlassian.net/browse/WIN-462):** Update error-proxy to pass through environment to Sentry

We need Sentry to work on both UAT boxes as per Production including pushing error logs through. This would ensure that Sentry errors can be seen, monitored and fixed before code is deployed to live.

Airbrake proxy needs to send an environment key in server.js as described in the Sentry notification API docs. The environment-name is already be passed through to error-proxy within an Airbrake 2.3 format notice, so we can use the variable here.


***Progress: 90%***

---

### Tasks

- [x] Update config for set the environment